### PR TITLE
use slurm environment variables to set dask vars

### DIFF
--- a/pathml_root_pipeline_dask.sl
+++ b/pathml_root_pipeline_dask.sl
@@ -1,12 +1,12 @@
 #!/bin/bash -e
 #SBATCH --job-name=pathml_root_pipeline-dask
 #SBATCH --time=12:00:00
-#SBATCH --hint=multithread
-#SBATCH --partition=bigmem
-#SBATCH --mem-per-cpu=8G
+#SBATCH --hint=nomultithread
+#SBATCH --mem=32G
 #SBATCH --ntasks=1
 #SBATCH --cpus-per-task=12
 
+module unload XALT
 module load Singularity
 
 # Bind directories and append SLURM job ID to output directory
@@ -15,4 +15,4 @@ export SINGULARITY_BIND="/nesi/nobackup/uoa03709/input:/var/inputdata/work-dir,\
 /nesi/nobackup/uoa03709/output/${SLURM_JOB_ID:-0}:/var/outputdata"
 
 # Run container %runscript
-srun singularity exec /nesi/project/uoa03709/containers/sif/smp-cv_0.1.6.sif python /var/inputdata/root_pipeline_dask.py
+srun singularity exec /nesi/project/uoa03709/containers/sif/smp-cv_0.1.6.sif env PYTHONUNBUFFERED=1 python /var/inputdata/root_pipeline_dask.py

--- a/root_pipeline_dask.py
+++ b/root_pipeline_dask.py
@@ -19,7 +19,6 @@ import numpy
 import tqdm
 import os
 import dask
-import dask_mpi as dm
 from dask.distributed import Client, LocalCluster
 import distributed
 # dask.config.set({"distributed.comm.timeouts.tcp": "180s"})
@@ -48,8 +47,15 @@ def root_pipeline():
 
 # Press the green button in the gutter to run the script.
 if __name__ == '__main__':
-    dm.initialize(local_directory='/var/inputdata/')
-    cluster = LocalCluster(n_workers=12, threads_per_worker=1, processes=True, memory_limit="8GB")
+    # loading number of workers and memory limits from the slurm environment
+    n_workers = int(os.environ["SLURM_CPUS_PER_TASK"])
+    total_mem_bytes = int(os.environ["SLURM_MEM_PER_NODE"]) * 1024 * 1024  # SLURM_MEM_PER_NODE is in MB
+    mem_limit_bytes = total_mem_bytes // n_workers
+    print(f"n_workers: {n_workers}")
+    print(f"total memory: {total_mem_bytes / 1024 / 1024} MB")
+    print(f"mem limit per worker: {mem_limit_bytes / 1024 / 1024:.0f} MB")
+
+    cluster = LocalCluster(n_workers=n_workers, threads_per_worker=1, processes=True, memory_limit=mem_limit_bytes)
     client = Client(cluster)
     size = 512
     save_location = os.path.join("/var/inputdata/py-data/whole-h5/TCGA-14-0789-preprocessed_{size}.h5path")


### PR DESCRIPTION
- use `--cpus-per-task` value for n_workers
- use `--mem` value for memory limit - note: you must use `--mem` instead of `--mem-per-cpu` with these changes (`--mem` sets the total memory required)
- unload XALT module as it can sometimes interfere with containers
- add `env PYTHONUNBUFFERED=1` before calling the python script so python output gets printed immediately (can remove this if not helpful)