### PR TITLE
use more recent miniconda script in container build

### DIFF
--- a/container-building/build_sif.sl
+++ b/container-building/build_sif.sl
@@ -1,9 +1,10 @@
 #!/bin/bash -e
 #SBATCH --job-name=apptainer_build
 #SBATCH --partition=milan
-#SBATCH --time=0-01:00:00
+#SBATCH --time=0-02:00:00
 #SBATCH --mem=8GB
-#SBATCH --cpus-per-task=4
+#SBATCH --ntasks=1
+#SBATCH --cpus-per-task=1
 
 module purge
 module load Apptainer/1.1.2

--- a/container-building/smp_0-2-9-1.def
+++ b/container-building/smp_0-2-9-1.def
@@ -36,11 +36,11 @@ From: ubuntu:22.04
 	software-properties-common 
 	
 	mkdir ~/TMP
-	wget https://repo.anaconda.com/miniconda/Miniconda3-py38_4.10.3-Linux-x86_64.sh 
-	TMPDIR=~/TMP bash Miniconda3-py38_4.10.3-Linux-x86_64.sh -bfp /opt/miniconda3/ 
-	rm -f Miniconda3-py38_4.10.3-Linux-x86_64.sh 
-	rm -rf /var/lib/apt/lists/* 
-	mkdir /var/inputdata 
+    wget -O miniconda.sh https://repo.anaconda.com/miniconda/Miniconda3-py38_23.3.1-0-Linux-x86_64.sh
+	TMPDIR=~/TMP bash miniconda.sh -bfp /opt/miniconda3/
+	rm -f miniconda.sh
+	rm -rf /var/lib/apt/lists/*
+	mkdir /var/inputdata
 	mkdir /var/outputdata
 	
 	export PATH="/opt/miniconda3/bin:$PATH" 
@@ -72,4 +72,3 @@ From: ubuntu:22.04
 
 %runscript
     echo "Container was created $NOW"
-	


### PR DESCRIPTION
This worked on Mahuika (milan) for me but took over 1 hour so I updated the wall time in the slurm script. It didn't seem to benefit from multiple cores so I also set cpus-per-task to 1.